### PR TITLE
Fix port 25 forwarding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ db:
 mailin:
   image: loomio/mailin-docker
   ports:
-    - 25:25
+    - "25:25"
   links:
     - loomio
   environment:


### PR DESCRIPTION
The port 25 forwarding was not working unless I quote the `25:25` setting.

Distribution : `Ubuntu 14.04.4 LTS`
docker: `docker-engine 1.11.2-0~trusty`
docker-compose: 

```
    docker-compose version 1.6.2, build 4d72027
    docker-py version: 1.7.2
    CPython version: 2.7.9
    OpenSSL version: OpenSSL 1.0.1e 11 Feb 2013
```
