### PR TITLE
resolve #5 as suggested by @FramaJosephK

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,17 +30,17 @@ loomio:
   environment:
     - DATABASE_URL=postgresql://postgres:password@db/loomio_production
   volumes:
-    - ./attachments:/loomio/public/system/attachments
+    - ./uploads:/loomio/public/system
 
 worker:
   image: loomio/loomio
   env_file: ./env
   links:
-    - db:db
+    - db
   environment:
     - DATABASE_URL=postgresql://postgres:password@db/loomio_production
   volumes:
-    - ./attachments:/loomio/public/system/attachments
+    - ./uploads:/loomio/public/system
   command: "bundle exec rake jobs:work"
 
 db:


### PR DESCRIPTION
The current configuration is losing group cover photos and user and group avatars when shutting the application server. This fix resolves the issue.

When updating loomio-deploy by `git pull`, people should fix the attachments store before bringing the server up again:

    mkdir uploads
    mv attachments/ uploads/