### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /env
 /faye_env
 /pgdata
-/attachments
+/uploads
+/certificates
+/nginx


### PR DESCRIPTION
* `/attachments` was renamed to `/uploads` in c782a8f5ee1302ad2ba1a18cffcb1d956fd0e615
* I have added `/certificates` and `/nginx` by analogy to `/pgdata`, `/env` and `faye_env`
 