### PR TITLE
Prefer non-sparse swapfile

### DIFF
--- a/scripts/create_swapfile
+++ b/scripts/create_swapfile
@@ -1,5 +1,6 @@
 #!/bin/sh
-fallocate -l 4G /swapfile
+# fallocate -l 4G /swapfile
+dd if=/dev/zero of=swapfile count=4000 bs=1MiB
 chmod 600 /swapfile
 mkswap /swapfile
 swapon /swapfile


### PR DESCRIPTION
It seems a sparse file is not good for swap on some filesystems (btrfs and xfs at least?). See https://bugzilla.redhat.com/show_bug.cgi?id=1129205#c3