### PR TITLE
Change regular IP to IP for doc (RFC 5737)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ If you just want a local install of Loomio for development, see [Setting up a Lo
 * An SMTP server
 
 ## Network configuration
-For this example, the hostname will be loomio.example.com and the IP address is 123.123.123.123
+For this example, the hostname will be loomio.example.com and the IP address is 192.0.2.1
 
 ### DNS Records
 To allow people to access the site via your hostname you need an A record:
 
 ```
-A loomio.example.com, 123.123.123.123
+A loomio.example.com, 192.0.2.1
 ```
 
 Loomio supports "Reply by email" and to enable this you need an MX record so mail servers know where to direct these emails.


### PR DESCRIPTION
Per RFC 5737, section 3:

>The blocks 192.0.2.0/24 (TEST-NET-1), 198.51.100.0/24 (TEST-NET-2), and 203.0.113.0/24 (TEST-NET-3) are provided for use in documentation.

https://www.rfc-editor.org/rfc/rfc5737#section-3