### PR TITLE
Added channels setup hint to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ This script will create and mount a 4GB swapfile. If you have less than 2GB RAM 
 
 By default, docker-compose.yml includes an nginx proxy container that automatically handles fetching an SSL certificate via LetsEncrypt.org. If you don't need SSL termination, or you're running Loomio from behind a proxy, you can safely remove the nginx services from the docker-compose.yml file. The loomio app container will happily speak plain HTTP on port 3000 (by default). Configuring reverse proxies and other advanced configurations are outside the scope of this documentation, but at minimum it's suggested to preserve the HTTP host header and to set X-FORWARDED-PROTO if terminating SSL upstream.
 
+If using Traefik or similar, make sure to expose the channels and hocuspocus containers (port 5000) just like the main app using their respective route (channels.CANONICAL_HOST / hocuspocus.CANONICAL_HOST). Otherwise, they will not be reachable by the client application (collaboration features and editing will not work starting 2.25.0).
+
 ### Create your ENV files
 This script creates `env` files configured for you. It also creates directories on the host to hold user data.
 


### PR DESCRIPTION
**tldr; with patch 2.25.0, the setup instructions for channels could be improved.** It seems like the channels container is intended to be exposed to the internet (as well as through any potential reverse proxies such in my case). I assume this is also the case for hocuspocus? (No idea, please correct me if I'm wrong).
 
Also, great work with this software :heart: 

## Background

I started hosting loomio quite recently (behind Traefik rproxy) and am quite satisfied overall. With the latest patch, there was a bugfix that made me realize that the collab feature (which I didn't know existed until then) had never worked! Back at inital setup, except for edits on comments/threads requiring to press reset (which wasn't an issue back then), everything else seemed fine to me. No server side bugs in the logs, only a small, innocent INFO in the loomio logs that there was a rack-timeout.

Two months later and after said patch (2.25.3), I investigate and realized the channels service used for the collab feature has to be the issue editing only works with reset; However, no matter how many tcpdumps I tried how often I made sure that in fact all containers could reach each other, I couldn't see any traffic to the main app to channels. I checked everything twice and still believed I followed all instructions on loomio-deploy.

After a long day of testing I now finally understand that **channelss (and hocuspocus?)** seemingly have to be exposed to the client side application, that means through the reverse proxy and to the public internet. This does not seem to be documented anywhere  (not even in [the loomio-deploy compose](https://github.com/loomio/loomio-deploy/blob/master/docker-compose.yml)) + the instructions in the readme made me feel save  that this was NOT the issue by specifically addressing the "most important" setup steps for hosting behind rproxies. If I hadn't randomly seen a almost unrelated SO post about the javascript console *I would have never tried* to look into my browser console to even see the error messages. After all, it has to be a server side issue. *Right? **Right...?!***

Long story shorter, I exposed channels (and hocuspocus?) that listen on port 5000, just like I do with the main app. Everything works now.


