### PR TITLE
Use environment variable for PostgreSQL password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ services:
       - POSTGRES_HOST=db
       - POSTGRES_DB=loomio_production
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=password
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_EXTRA_OPTS=-Z6 --schema=public --blobs
       - SCHEDULE=@daily
       - BACKUP_KEEP_DAYS=7


### PR DESCRIPTION
I wanted to trigger a backup via docker compose with something like: `docker compose run pgbackups /backup.sh` but found it wasn't working due to the password being different in the [.env](https://github.com/gingermusketeer/loomio-deploy/blob/0981988931df618cb670085035c70007d1305055/env_template#L65) file and the docker compose file.