### PR TITLE
Upgrade redis to v8.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
 
   redis:
     container_name: loomio-redis
-    image: redis:5.0
+    image: redis:8.4
     restart: unless-stopped
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']


### PR DESCRIPTION
Redis 5 used in [docker-compose.yml](https://github.com/loomio/loomio-deploy/blob/d1774fbb981c17abfbebffe1db51b2e0da0ef23e/docker-compose.yml#L91) is quite outdated and the image has a number of vulnerabilities:

<img width="845" height="294" alt="Image" src="https://github.com/user-attachments/assets/3cb6ee29-1ef1-41b0-84fe-2f61fad1e784" />

This PR upgrades the version to v8.4 which I believe will be the same version used in the [main repository](https://github.com/loomio/loomio/blob/40e76d31ec6c7895787e8b9c78eafcb204e7415f/.github/workflows/tests.yml#L32) for testing loomio

I think the main thing to be aware of is that Redis v7.2 and earlier had a BSD-3-Clause licence but is now [tri-licenced as RSALv2 or SSPLv1 or AGPLv3](https://redis.io/legal/licenses/#:~:text=full%20version%20history%20in%20the%20table%20below.). From my understanding of the licences, RSALv2  would be the best choice as it doesn't impose any licensing when Redis itself is not offered commercially. 